### PR TITLE
Sanitize parameter names, Add overload function generation

### DIFF
--- a/GDBridge.Generator/GDBridge.Generator/BridgeWriter.cs
+++ b/GDBridge.Generator/GDBridge.Generator/BridgeWriter.cs
@@ -1,8 +1,10 @@
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Text.RegularExpressions;
 using GDParser;
+using Microsoft.CodeAnalysis.CSharp;
 using SourceGeneratorUtils;
 
 namespace GDBridge.Generator;
@@ -42,35 +44,81 @@ class BridgeWriter
 
     public SourceWriter Functions(IEnumerable<GdFunction> functions)
     {
+        var scriptFunctions = new List<GdFunction>();
+
+        // Iterate over functions with default parameters omitted
         foreach (var function in functions)
         {
+            // Filter out functions which start with an underscore to avoid native function overrides
             if (function.Name.StartsWith("_"))
+            {
                 continue;
-            
+            }
+
+            var defaultParams = function.Parameters.Where(p => p.Name.Contains('=')).ToList();
+            if (!defaultParams.Any())
+            {
+                scriptFunctions.Add(function);
+                continue;
+            }
+            var nonDefaults = function.Parameters.Where(p => !defaultParams.Contains(p)).ToList();
+
+            // Add a new function for each parameter signature
+            for (var i = 0; i <= defaultParams.Count; i++)
+            {
+                var @params = new List<GdVariable>(nonDefaults);
+                @params.AddRange(defaultParams.Take(i));
+                scriptFunctions.Add(new GdFunction(function.Name, new ReadOnlyCollection<GdVariable>(@params),
+                    function.ReturnType));
+            }
+        }
+
+        foreach (var function in scriptFunctions)
+        {
             source.WriteEmptyLines(1)
-                .WriteLine($"""public {function.ReturnType.ToCSharpTypeString(availableTypes)} {Pascalize(function.Name)}({InParameters(function.Parameters)}) => GdObject.Call("{function.Name}"{CallParameters(function.Parameters)}){GetTypeCast(function.ReturnType)};""");
+                .WriteLine(
+                    $"""public {function.ReturnType.ToCSharpTypeString(availableTypes)} {Pascalize(function.Name)}({InParameters(function.Parameters)}) => GdObject.Call("{function.Name}"{CallParameters(function.Parameters)}){GetTypeCast(function.ReturnType)};""");
         }
 
         return source;
     }
     string InParameters(IEnumerable<GdVariable> parameters) => string.Join(", ", parameters.Select(InParameter));
-    string InParameter(GdVariable parameter) => $"{parameter.Type.ToCSharpTypeString(availableTypes)} {Pascalize(parameter.Name)}";
+    string InParameter(GdVariable parameter) => $"{parameter.Type.ToCSharpTypeString(availableTypes)} {Pascalize(SanitizeParameter(parameter.Name))}";
     string Pascalize(string text) => configuration.UsePascalCase ? Regex.Replace(text, "(?:^|_| +)(.)", match => match.Groups[1].Value.ToUpper()) : text;
+
+    string SanitizeParameter(string parameter)
+    {
+        // Return parameter if it's already valid
+        if (SyntaxFacts.GetKeywordKind(parameter) == SyntaxKind.None && SyntaxFacts.IsValidIdentifier(parameter))
+        {
+            return parameter;
+        }
+
+        // Remove default parameter values
+        var param = parameter;
+        if (parameter.Contains('='))
+        {
+            param = parameter.Substring(0, parameter.IndexOf('=')).Trim();
+        }
+
+        // Validate it's not a reserved keyword
+        return SyntaxFacts.GetKeywordKind(param) == SyntaxKind.None && SyntaxFacts.IsValidIdentifier(param) ? param : $"@{param}";
+    }
 
     string CallParameters(IEnumerable<GdVariable> parameters)
     {
         parameters = parameters.ToList();
         if (!parameters.Any())
             return "";
-        return $", {string.Join(", ", parameters.Select(p => Pascalize(p.Name)))}";
+        return $", {string.Join(", ", parameters.Select(p => Pascalize(SanitizeParameter(p.Name))))}";
     }
-    
+
     string GetTypeCast(GdType type)
     {
         var typeString = type.ToCSharpTypeString(availableTypes);
         if (typeString is "Variant" or "void")
             return "";
-        
+
         return $".As<{typeString}>()";
     }
 


### PR DESCRIPTION
- Added parameter name sanitation, where if a parameter is any reserved keyword (such as `operator`), it will not result in invalid generated code.
- Strip default values from parameter signature, and instead generate overload functions. This should prevent any issue where the parameters are assigned to non-constant values or values not exposed to the C# bridge.

Here is an example of GDScript function with both a reserved keyword and a default value assignment.
```gdscript
func example_func(non_default_param, operator = idx):
	pass
```

Here is how it was generated:
![image](https://github.com/Jemy191/GDBridge/assets/108483531/bcb9239a-8a51-4470-b3f2-e7e657c47ef0)

Here is how it's now generated:
![image](https://github.com/Jemy191/GDBridge/assets/108483531/d12e553d-e745-4e67-805a-c26ca1b0df2d)
