### PR TITLE
Fix variant not being explicitly constructed

### DIFF
--- a/GDBridge.Generator/GDBridge.Generator.Tests/Verified/AllNoConfig/Arena.gd#ArenaBridge.verified.cs
+++ b/GDBridge.Generator/GDBridge.Generator.Tests/Verified/AllNoConfig/Arena.gd#ArenaBridge.verified.cs
@@ -8,7 +8,7 @@ public partial class ArenaBridge : GDScriptBridge
     public Godot.NodePath game_startup
     {
         get => GdObject.Get("game_startup").As<Godot.NodePath>();
-        set => GdObject.Set("game_startup", value);
+        set => GdObject.Set("game_startup", Godot.Variant.From(value));
     }
 
     public ArenaBridge(GodotObject gdObject) : base(gdObject) {}

--- a/GDBridge.Generator/GDBridge.Generator.Tests/Verified/AllNoConfig/BuiltInType.gd#BuiltInTypeBridge.verified.cs
+++ b/GDBridge.Generator/GDBridge.Generator.Tests/Verified/AllNoConfig/BuiltInType.gd#BuiltInTypeBridge.verified.cs
@@ -8,229 +8,229 @@ public partial class BuiltInTypeBridge : GDScriptBridge
     public Variant var_variant
     {
         get => GdObject.Get("var_variant");
-        set => GdObject.Set("var_variant", value);
+        set => GdObject.Set("var_variant", Godot.Variant.From(value));
     }
 
     public Godot.Aabb var_aabb
     {
         get => GdObject.Get("var_aabb").As<Godot.Aabb>();
-        set => GdObject.Set("var_aabb", value);
+        set => GdObject.Set("var_aabb", Godot.Variant.From(value));
     }
 
     public Godot.Collections.Array var_array
     {
         get => GdObject.Get("var_array").As<Godot.Collections.Array>();
-        set => GdObject.Set("var_array", value);
+        set => GdObject.Set("var_array", Godot.Variant.From(value));
     }
 
     public Godot.Basis var_basis
     {
         get => GdObject.Get("var_basis").As<Godot.Basis>();
-        set => GdObject.Set("var_basis", value);
+        set => GdObject.Set("var_basis", Godot.Variant.From(value));
     }
 
     public bool var_bool
     {
         get => GdObject.Get("var_bool").As<bool>();
-        set => GdObject.Set("var_bool", value);
+        set => GdObject.Set("var_bool", Godot.Variant.From(value));
     }
 
     public Godot.Callable var_callable
     {
         get => GdObject.Get("var_callable").As<Godot.Callable>();
-        set => GdObject.Set("var_callable", value);
+        set => GdObject.Set("var_callable", Godot.Variant.From(value));
     }
 
     public Godot.Color var_color
     {
         get => GdObject.Get("var_color").As<Godot.Color>();
-        set => GdObject.Set("var_color", value);
+        set => GdObject.Set("var_color", Godot.Variant.From(value));
     }
 
     public Godot.Collections.Dictionary var_dictionary
     {
         get => GdObject.Get("var_dictionary").As<Godot.Collections.Dictionary>();
-        set => GdObject.Set("var_dictionary", value);
+        set => GdObject.Set("var_dictionary", Godot.Variant.From(value));
     }
 
     public double var_float
     {
         get => GdObject.Get("var_float").As<double>();
-        set => GdObject.Set("var_float", value);
+        set => GdObject.Set("var_float", Godot.Variant.From(value));
     }
 
     public long var_int
     {
         get => GdObject.Get("var_int").As<long>();
-        set => GdObject.Set("var_int", value);
+        set => GdObject.Set("var_int", Godot.Variant.From(value));
     }
 
     public Godot.NodePath var_nodepath
     {
         get => GdObject.Get("var_nodepath").As<Godot.NodePath>();
-        set => GdObject.Set("var_nodepath", value);
+        set => GdObject.Set("var_nodepath", Godot.Variant.From(value));
     }
 
     public Godot.GodotObject var_object
     {
         get => GdObject.Get("var_object").As<Godot.GodotObject>();
-        set => GdObject.Set("var_object", value);
+        set => GdObject.Set("var_object", Godot.Variant.From(value));
     }
 
     public byte[] var_packedbytearray
     {
         get => GdObject.Get("var_packedbytearray").As<byte[]>();
-        set => GdObject.Set("var_packedbytearray", value);
+        set => GdObject.Set("var_packedbytearray", Godot.Variant.From(value));
     }
 
     public Godot.Color[] var_packedcolorarray
     {
         get => GdObject.Get("var_packedcolorarray").As<Godot.Color[]>();
-        set => GdObject.Set("var_packedcolorarray", value);
+        set => GdObject.Set("var_packedcolorarray", Godot.Variant.From(value));
     }
 
     public float[] var_packedfloat32array
     {
         get => GdObject.Get("var_packedfloat32array").As<float[]>();
-        set => GdObject.Set("var_packedfloat32array", value);
+        set => GdObject.Set("var_packedfloat32array", Godot.Variant.From(value));
     }
 
     public double[] var_packedfloat64array
     {
         get => GdObject.Get("var_packedfloat64array").As<double[]>();
-        set => GdObject.Set("var_packedfloat64array", value);
+        set => GdObject.Set("var_packedfloat64array", Godot.Variant.From(value));
     }
 
     public int[] var_packedint32array
     {
         get => GdObject.Get("var_packedint32array").As<int[]>();
-        set => GdObject.Set("var_packedint32array", value);
+        set => GdObject.Set("var_packedint32array", Godot.Variant.From(value));
     }
 
     public long[] var_packedint64array
     {
         get => GdObject.Get("var_packedint64array").As<long[]>();
-        set => GdObject.Set("var_packedint64array", value);
+        set => GdObject.Set("var_packedint64array", Godot.Variant.From(value));
     }
 
     public string[] var_packedstringarray
     {
         get => GdObject.Get("var_packedstringarray").As<string[]>();
-        set => GdObject.Set("var_packedstringarray", value);
+        set => GdObject.Set("var_packedstringarray", Godot.Variant.From(value));
     }
 
     public Godot.Vector2[] var_packedvector2array
     {
         get => GdObject.Get("var_packedvector2array").As<Godot.Vector2[]>();
-        set => GdObject.Set("var_packedvector2array", value);
+        set => GdObject.Set("var_packedvector2array", Godot.Variant.From(value));
     }
 
     public Godot.Vector3[] var_packedvector3array
     {
         get => GdObject.Get("var_packedvector3array").As<Godot.Vector3[]>();
-        set => GdObject.Set("var_packedvector3array", value);
+        set => GdObject.Set("var_packedvector3array", Godot.Variant.From(value));
     }
 
     public Godot.Plane var_plane
     {
         get => GdObject.Get("var_plane").As<Godot.Plane>();
-        set => GdObject.Set("var_plane", value);
+        set => GdObject.Set("var_plane", Godot.Variant.From(value));
     }
 
     public Godot.Projection var_projection
     {
         get => GdObject.Get("var_projection").As<Godot.Projection>();
-        set => GdObject.Set("var_projection", value);
+        set => GdObject.Set("var_projection", Godot.Variant.From(value));
     }
 
     public Godot.Quaternion var_quaternion
     {
         get => GdObject.Get("var_quaternion").As<Godot.Quaternion>();
-        set => GdObject.Set("var_quaternion", value);
+        set => GdObject.Set("var_quaternion", Godot.Variant.From(value));
     }
 
     public Godot.Rect2 var_rect2
     {
         get => GdObject.Get("var_rect2").As<Godot.Rect2>();
-        set => GdObject.Set("var_rect2", value);
+        set => GdObject.Set("var_rect2", Godot.Variant.From(value));
     }
 
     public Godot.Rect2I var_rect2i
     {
         get => GdObject.Get("var_rect2i").As<Godot.Rect2I>();
-        set => GdObject.Set("var_rect2i", value);
+        set => GdObject.Set("var_rect2i", Godot.Variant.From(value));
     }
 
     public Godot.Rid var_rid
     {
         get => GdObject.Get("var_rid").As<Godot.Rid>();
-        set => GdObject.Set("var_rid", value);
+        set => GdObject.Set("var_rid", Godot.Variant.From(value));
     }
 
     public Godot.Signal var_signal
     {
         get => GdObject.Get("var_signal").As<Godot.Signal>();
-        set => GdObject.Set("var_signal", value);
+        set => GdObject.Set("var_signal", Godot.Variant.From(value));
     }
 
     public string var_string
     {
         get => GdObject.Get("var_string").As<string>();
-        set => GdObject.Set("var_string", value);
+        set => GdObject.Set("var_string", Godot.Variant.From(value));
     }
 
     public Godot.StringName var_stringname
     {
         get => GdObject.Get("var_stringname").As<Godot.StringName>();
-        set => GdObject.Set("var_stringname", value);
+        set => GdObject.Set("var_stringname", Godot.Variant.From(value));
     }
 
     public Godot.Transform2D var_transform2d
     {
         get => GdObject.Get("var_transform2d").As<Godot.Transform2D>();
-        set => GdObject.Set("var_transform2d", value);
+        set => GdObject.Set("var_transform2d", Godot.Variant.From(value));
     }
 
     public Godot.Transform3D var_transform3d
     {
         get => GdObject.Get("var_transform3d").As<Godot.Transform3D>();
-        set => GdObject.Set("var_transform3d", value);
+        set => GdObject.Set("var_transform3d", Godot.Variant.From(value));
     }
 
     public Godot.Vector2 var_vector2
     {
         get => GdObject.Get("var_vector2").As<Godot.Vector2>();
-        set => GdObject.Set("var_vector2", value);
+        set => GdObject.Set("var_vector2", Godot.Variant.From(value));
     }
 
     public Godot.Vector2I var_vector2i
     {
         get => GdObject.Get("var_vector2i").As<Godot.Vector2I>();
-        set => GdObject.Set("var_vector2i", value);
+        set => GdObject.Set("var_vector2i", Godot.Variant.From(value));
     }
 
     public Godot.Vector3 var_vector3
     {
         get => GdObject.Get("var_vector3").As<Godot.Vector3>();
-        set => GdObject.Set("var_vector3", value);
+        set => GdObject.Set("var_vector3", Godot.Variant.From(value));
     }
 
     public Godot.Vector3I var_vector3i
     {
         get => GdObject.Get("var_vector3i").As<Godot.Vector3I>();
-        set => GdObject.Set("var_vector3i", value);
+        set => GdObject.Set("var_vector3i", Godot.Variant.From(value));
     }
 
     public Godot.Vector4 var_vector4
     {
         get => GdObject.Get("var_vector4").As<Godot.Vector4>();
-        set => GdObject.Set("var_vector4", value);
+        set => GdObject.Set("var_vector4", Godot.Variant.From(value));
     }
 
     public Godot.Vector4I var_vector4i
     {
         get => GdObject.Get("var_vector4i").As<Godot.Vector4I>();
-        set => GdObject.Set("var_vector4i", value);
+        set => GdObject.Set("var_vector4i", Godot.Variant.From(value));
     }
 
     public BuiltInTypeBridge(GodotObject gdObject) : base(gdObject) {}

--- a/GDBridge.Generator/GDBridge.Generator.Tests/Verified/AllNoConfig/CSharpGDObject.gd#CSharpGDObjectBridge.verified.cs
+++ b/GDBridge.Generator/GDBridge.Generator.Tests/Verified/AllNoConfig/CSharpGDObject.gd#CSharpGDObjectBridge.verified.cs
@@ -8,7 +8,7 @@ public partial class CSharpGDObjectBridge : GDScriptBridge
     public TestGDObject test_object
     {
         get => GdObject.Get("test_object").As<TestGDObject>();
-        set => GdObject.Set("test_object", value);
+        set => GdObject.Set("test_object", Godot.Variant.From(value));
     }
 
     public CSharpGDObjectBridge(GodotObject gdObject) : base(gdObject) {}

--- a/GDBridge.Generator/GDBridge.Generator.Tests/Verified/AllNoConfig/Card.gd#CardBridge.verified.cs
+++ b/GDBridge.Generator/GDBridge.Generator.Tests/Verified/AllNoConfig/Card.gd#CardBridge.verified.cs
@@ -8,13 +8,13 @@ public partial class CardBridge : GDScriptBridge
     public Godot.Label name_label
     {
         get => GdObject.Get("name_label").As<Godot.Label>();
-        set => GdObject.Set("name_label", value);
+        set => GdObject.Set("name_label", Godot.Variant.From(value));
     }
 
     public Godot.Label cost_label
     {
         get => GdObject.Get("cost_label").As<Godot.Label>();
-        set => GdObject.Set("cost_label", value);
+        set => GdObject.Set("cost_label", Godot.Variant.From(value));
     }
 
     public CardBridge(GodotObject gdObject) : base(gdObject) {}

--- a/GDBridge.Generator/GDBridge.Generator.Tests/Verified/AllNoConfig/CardPath.gd#CardPathBridge.verified.cs
+++ b/GDBridge.Generator/GDBridge.Generator.Tests/Verified/AllNoConfig/CardPath.gd#CardPathBridge.verified.cs
@@ -8,31 +8,31 @@ public partial class CardPathBridge : GDScriptBridge
     public long width
     {
         get => GdObject.Get("width").As<long>();
-        set => GdObject.Set("width", value);
+        set => GdObject.Set("width", Godot.Variant.From(value));
     }
 
     public long height
     {
         get => GdObject.Get("height").As<long>();
-        set => GdObject.Set("height", value);
+        set => GdObject.Set("height", Godot.Variant.From(value));
     }
 
     public double curve_ratio
     {
         get => GdObject.Get("curve_ratio").As<double>();
-        set => GdObject.Set("curve_ratio", value);
+        set => GdObject.Set("curve_ratio", Godot.Variant.From(value));
     }
 
     public double separation
     {
         get => GdObject.Get("separation").As<double>();
-        set => GdObject.Set("separation", value);
+        set => GdObject.Set("separation", Godot.Variant.From(value));
     }
 
     public double padding
     {
         get => GdObject.Get("padding").As<double>();
-        set => GdObject.Set("padding", value);
+        set => GdObject.Set("padding", Godot.Variant.From(value));
     }
 
     public CardPathBridge(GodotObject gdObject) : base(gdObject) {}

--- a/GDBridge.Generator/GDBridge.Generator.Tests/Verified/AllNoConfig/ChooseDeck.gd#ChooseDeckBridge.verified.cs
+++ b/GDBridge.Generator/GDBridge.Generator.Tests/Verified/AllNoConfig/ChooseDeck.gd#ChooseDeckBridge.verified.cs
@@ -8,13 +8,13 @@ public partial class ChooseDeckBridge : GDScriptBridge
     public Godot.PackedScene deckEntryScene
     {
         get => GdObject.Get("deckEntryScene").As<Godot.PackedScene>();
-        set => GdObject.Set("deckEntryScene", value);
+        set => GdObject.Set("deckEntryScene", Godot.Variant.From(value));
     }
 
     public Godot.PackedScene deckBuilderScene
     {
         get => GdObject.Get("deckBuilderScene").As<Godot.PackedScene>();
-        set => GdObject.Set("deckBuilderScene", value);
+        set => GdObject.Set("deckBuilderScene", Godot.Variant.From(value));
     }
 
     public ChooseDeckBridge(GodotObject gdObject) : base(gdObject) {}

--- a/GDBridge.Generator/GDBridge.Generator.Tests/Verified/AllNoConfig/DeckBuilder.gd#DeckBuilderBridge.verified.cs
+++ b/GDBridge.Generator/GDBridge.Generator.Tests/Verified/AllNoConfig/DeckBuilder.gd#DeckBuilderBridge.verified.cs
@@ -8,7 +8,7 @@ public partial class DeckBuilderBridge : GDScriptBridge
     public bool createNewDeck
     {
         get => GdObject.Get("createNewDeck").As<bool>();
-        set => GdObject.Set("createNewDeck", value);
+        set => GdObject.Set("createNewDeck", Godot.Variant.From(value));
     }
 
     public DeckBuilderBridge(GodotObject gdObject) : base(gdObject) {}

--- a/GDBridge.Generator/GDBridge.Generator.Tests/Verified/AllNoConfig/DeckDataTest.gd#DeckDataTestBridge.verified.cs
+++ b/GDBridge.Generator/GDBridge.Generator.Tests/Verified/AllNoConfig/DeckDataTest.gd#DeckDataTestBridge.verified.cs
@@ -8,7 +8,7 @@ public partial class DeckDataTestBridge : GDScriptBridge
     public CardGame.Core.Data.DeckData test_object
     {
         get => GdObject.Get("test_object").As<CardGame.Core.Data.DeckData>();
-        set => GdObject.Set("test_object", value);
+        set => GdObject.Set("test_object", Godot.Variant.From(value));
     }
 
     public DeckDataTestBridge(GodotObject gdObject) : base(gdObject) {}

--- a/GDBridge.Generator/GDBridge.Generator.Tests/Verified/AllNoConfig/DeckEntry.gd#DeckEntryBridge.verified.cs
+++ b/GDBridge.Generator/GDBridge.Generator.Tests/Verified/AllNoConfig/DeckEntry.gd#DeckEntryBridge.verified.cs
@@ -8,13 +8,13 @@ public partial class DeckEntryBridge : GDScriptBridge
     public long deckId
     {
         get => GdObject.Get("deckId").As<long>();
-        set => GdObject.Set("deckId", value);
+        set => GdObject.Set("deckId", Godot.Variant.From(value));
     }
 
     public Godot.Variant chooseDeck
     {
         get => GdObject.Get("chooseDeck").As<Godot.Variant>();
-        set => GdObject.Set("chooseDeck", value);
+        set => GdObject.Set("chooseDeck", Godot.Variant.From(value));
     }
 
     public DeckEntryBridge(GodotObject gdObject) : base(gdObject) {}

--- a/GDBridge.Generator/GDBridge.Generator.Tests/Verified/AllNoConfig/Hand.gd#HandBridge.verified.cs
+++ b/GDBridge.Generator/GDBridge.Generator.Tests/Verified/AllNoConfig/Hand.gd#HandBridge.verified.cs
@@ -8,13 +8,13 @@ public partial class HandBridge : GDScriptBridge
     public Godot.PackedScene card_scene
     {
         get => GdObject.Get("card_scene").As<Godot.PackedScene>();
-        set => GdObject.Set("card_scene", value);
+        set => GdObject.Set("card_scene", Godot.Variant.From(value));
     }
 
     public Godot.Node card_container
     {
         get => GdObject.Get("card_container").As<Godot.Node>();
-        set => GdObject.Set("card_container", value);
+        set => GdObject.Set("card_container", Godot.Variant.From(value));
     }
 
     public HandBridge(GodotObject gdObject) : base(gdObject) {}

--- a/GDBridge.Generator/GDBridge.Generator.Tests/Verified/AllNoConfig/Menu.gd#MenuBridge.verified.cs
+++ b/GDBridge.Generator/GDBridge.Generator.Tests/Verified/AllNoConfig/Menu.gd#MenuBridge.verified.cs
@@ -8,7 +8,7 @@ public partial class MenuBridge : GDScriptBridge
     public Godot.Variant chooseDeck
     {
         get => GdObject.Get("chooseDeck").As<Godot.Variant>();
-        set => GdObject.Set("chooseDeck", value);
+        set => GdObject.Set("chooseDeck", Godot.Variant.From(value));
     }
 
     public MenuBridge(GodotObject gdObject) : base(gdObject) {}

--- a/GDBridge.Generator/GDBridge.Generator.Tests/Verified/AllNoConfig/SceneLoader.gd#SceneLoaderBridge.verified.cs
+++ b/GDBridge.Generator/GDBridge.Generator.Tests/Verified/AllNoConfig/SceneLoader.gd#SceneLoaderBridge.verified.cs
@@ -8,25 +8,25 @@ public partial class SceneLoaderBridge : GDScriptBridge
     public Godot.PackedScene menuScene
     {
         get => GdObject.Get("menuScene").As<Godot.PackedScene>();
-        set => GdObject.Set("menuScene", value);
+        set => GdObject.Set("menuScene", Godot.Variant.From(value));
     }
 
     public Godot.PackedScene arenaScene
     {
         get => GdObject.Get("arenaScene").As<Godot.PackedScene>();
-        set => GdObject.Set("arenaScene", value);
+        set => GdObject.Set("arenaScene", Godot.Variant.From(value));
     }
 
     public Godot.PackedScene deckbuilderScene
     {
         get => GdObject.Get("deckbuilderScene").As<Godot.PackedScene>();
-        set => GdObject.Set("deckbuilderScene", value);
+        set => GdObject.Set("deckbuilderScene", Godot.Variant.From(value));
     }
 
     public Godot.Node current_scene
     {
         get => GdObject.Get("current_scene").As<Godot.Node>();
-        set => GdObject.Set("current_scene", value);
+        set => GdObject.Set("current_scene", Godot.Variant.From(value));
     }
 
     public SceneLoaderBridge(GodotObject gdObject) : base(gdObject) {}

--- a/GDBridge.Generator/GDBridge.Generator.Tests/Verified/AllNoConfig/ScriptWithPropertyAndGetSetFunc.gd#ScriptWithPropertyAndGetSetFuncBridge.verified.cs
+++ b/GDBridge.Generator/GDBridge.Generator.Tests/Verified/AllNoConfig/ScriptWithPropertyAndGetSetFunc.gd#ScriptWithPropertyAndGetSetFuncBridge.verified.cs
@@ -8,7 +8,7 @@ public partial class ScriptWithPropertyAndGetSetFuncBridge : GDScriptBridge
     public Variant limit_target
     {
         get => GdObject.Get("limit_target");
-        set => GdObject.Set("limit_target", value);
+        set => GdObject.Set("limit_target", Godot.Variant.From(value));
     }
 
     public ScriptWithPropertyAndGetSetFuncBridge(GodotObject gdObject) : base(gdObject) {}

--- a/GDBridge.Generator/GDBridge.Generator.Tests/Verified/AllNoConfig/TestNonBuiltinGodotType.gd#TestNonBuiltinGodotTypeBridge.verified.cs
+++ b/GDBridge.Generator/GDBridge.Generator.Tests/Verified/AllNoConfig/TestNonBuiltinGodotType.gd#TestNonBuiltinGodotTypeBridge.verified.cs
@@ -8,7 +8,7 @@ public partial class TestNonBuiltinGodotTypeBridge : GDScriptBridge
     public Godot.Node2D node
     {
         get => GdObject.Get("node").As<Godot.Node2D>();
-        set => GdObject.Set("node", value);
+        set => GdObject.Set("node", Godot.Variant.From(value));
     }
 
     public TestNonBuiltinGodotTypeBridge(GodotObject gdObject) : base(gdObject) {}

--- a/GDBridge.Generator/GDBridge.Generator.Tests/Verified/AllNoConfig/TestWeird.gd#TestWeirdBridge.verified.cs
+++ b/GDBridge.Generator/GDBridge.Generator.Tests/Verified/AllNoConfig/TestWeird.gd#TestWeirdBridge.verified.cs
@@ -8,7 +8,7 @@ public partial class TestWeirdBridge : GDScriptBridge
     public Godot.Variant chooseDeck
     {
         get => GdObject.Get("chooseDeck").As<Godot.Variant>();
-        set => GdObject.Set("chooseDeck", value);
+        set => GdObject.Set("chooseDeck", Godot.Variant.From(value));
     }
 
     public TestWeirdBridge(GodotObject gdObject) : base(gdObject) {}

--- a/GDBridge.Generator/GDBridge.Generator.Tests/Verified/AllNoConfig/TypedArray.gd#TypedArrayBridge.verified.cs
+++ b/GDBridge.Generator/GDBridge.Generator.Tests/Verified/AllNoConfig/TypedArray.gd#TypedArrayBridge.verified.cs
@@ -8,229 +8,229 @@ public partial class TypedArrayBridge : GDScriptBridge
     public Godot.Collections.Array array_test
     {
         get => GdObject.Get("array_test").As<Godot.Collections.Array>();
-        set => GdObject.Set("array_test", value);
+        set => GdObject.Set("array_test", Godot.Variant.From(value));
     }
 
     public Godot.Collections.Array<Variant> array_variant
     {
         get => GdObject.Get("array_variant").As<Godot.Collections.Array<Variant>>();
-        set => GdObject.Set("array_variant", value);
+        set => GdObject.Set("array_variant", Godot.Variant.From(value));
     }
 
     public Godot.Collections.Array<Godot.Aabb> array_aabb
     {
         get => GdObject.Get("array_aabb").As<Godot.Collections.Array<Godot.Aabb>>();
-        set => GdObject.Set("array_aabb", value);
+        set => GdObject.Set("array_aabb", Godot.Variant.From(value));
     }
 
     public Godot.Collections.Array<Godot.Basis> array_basis
     {
         get => GdObject.Get("array_basis").As<Godot.Collections.Array<Godot.Basis>>();
-        set => GdObject.Set("array_basis", value);
+        set => GdObject.Set("array_basis", Godot.Variant.From(value));
     }
 
     public Godot.Collections.Array<bool> array_bool
     {
         get => GdObject.Get("array_bool").As<Godot.Collections.Array<bool>>();
-        set => GdObject.Set("array_bool", value);
+        set => GdObject.Set("array_bool", Godot.Variant.From(value));
     }
 
     public Godot.Collections.Array<Godot.Callable> array_callable
     {
         get => GdObject.Get("array_callable").As<Godot.Collections.Array<Godot.Callable>>();
-        set => GdObject.Set("array_callable", value);
+        set => GdObject.Set("array_callable", Godot.Variant.From(value));
     }
 
     public Godot.Collections.Array<Godot.Color> array_color
     {
         get => GdObject.Get("array_color").As<Godot.Collections.Array<Godot.Color>>();
-        set => GdObject.Set("array_color", value);
+        set => GdObject.Set("array_color", Godot.Variant.From(value));
     }
 
     public Godot.Collections.Array<Godot.Collections.Dictionary> array_dictionary
     {
         get => GdObject.Get("array_dictionary").As<Godot.Collections.Array<Godot.Collections.Dictionary>>();
-        set => GdObject.Set("array_dictionary", value);
+        set => GdObject.Set("array_dictionary", Godot.Variant.From(value));
     }
 
     public Godot.Collections.Array<double> array_float
     {
         get => GdObject.Get("array_float").As<Godot.Collections.Array<double>>();
-        set => GdObject.Set("array_float", value);
+        set => GdObject.Set("array_float", Godot.Variant.From(value));
     }
 
     public Godot.Collections.Array<long> array_int
     {
         get => GdObject.Get("array_int").As<Godot.Collections.Array<long>>();
-        set => GdObject.Set("array_int", value);
+        set => GdObject.Set("array_int", Godot.Variant.From(value));
     }
 
     public Godot.Collections.Array<Godot.NodePath> array_nodepath
     {
         get => GdObject.Get("array_nodepath").As<Godot.Collections.Array<Godot.NodePath>>();
-        set => GdObject.Set("array_nodepath", value);
+        set => GdObject.Set("array_nodepath", Godot.Variant.From(value));
     }
 
     public Godot.Collections.Array<Godot.GodotObject> array_object
     {
         get => GdObject.Get("array_object").As<Godot.Collections.Array<Godot.GodotObject>>();
-        set => GdObject.Set("array_object", value);
+        set => GdObject.Set("array_object", Godot.Variant.From(value));
     }
 
     public Godot.Collections.Array<byte[]> array_packedbytearray
     {
         get => GdObject.Get("array_packedbytearray").As<Godot.Collections.Array<byte[]>>();
-        set => GdObject.Set("array_packedbytearray", value);
+        set => GdObject.Set("array_packedbytearray", Godot.Variant.From(value));
     }
 
     public Godot.Collections.Array<Godot.Color[]> array_packedcolorarray
     {
         get => GdObject.Get("array_packedcolorarray").As<Godot.Collections.Array<Godot.Color[]>>();
-        set => GdObject.Set("array_packedcolorarray", value);
+        set => GdObject.Set("array_packedcolorarray", Godot.Variant.From(value));
     }
 
     public Godot.Collections.Array<float[]> array_packedfloat32array
     {
         get => GdObject.Get("array_packedfloat32array").As<Godot.Collections.Array<float[]>>();
-        set => GdObject.Set("array_packedfloat32array", value);
+        set => GdObject.Set("array_packedfloat32array", Godot.Variant.From(value));
     }
 
     public Godot.Collections.Array<double[]> array_packedfloat64array
     {
         get => GdObject.Get("array_packedfloat64array").As<Godot.Collections.Array<double[]>>();
-        set => GdObject.Set("array_packedfloat64array", value);
+        set => GdObject.Set("array_packedfloat64array", Godot.Variant.From(value));
     }
 
     public Godot.Collections.Array<int[]> array_packedint32array
     {
         get => GdObject.Get("array_packedint32array").As<Godot.Collections.Array<int[]>>();
-        set => GdObject.Set("array_packedint32array", value);
+        set => GdObject.Set("array_packedint32array", Godot.Variant.From(value));
     }
 
     public Godot.Collections.Array<long[]> array_packedint64array
     {
         get => GdObject.Get("array_packedint64array").As<Godot.Collections.Array<long[]>>();
-        set => GdObject.Set("array_packedint64array", value);
+        set => GdObject.Set("array_packedint64array", Godot.Variant.From(value));
     }
 
     public Godot.Collections.Array<string[]> array_packedstringarray
     {
         get => GdObject.Get("array_packedstringarray").As<Godot.Collections.Array<string[]>>();
-        set => GdObject.Set("array_packedstringarray", value);
+        set => GdObject.Set("array_packedstringarray", Godot.Variant.From(value));
     }
 
     public Godot.Collections.Array<Godot.Vector2[]> array_packedvector2array
     {
         get => GdObject.Get("array_packedvector2array").As<Godot.Collections.Array<Godot.Vector2[]>>();
-        set => GdObject.Set("array_packedvector2array", value);
+        set => GdObject.Set("array_packedvector2array", Godot.Variant.From(value));
     }
 
     public Godot.Collections.Array<Godot.Vector3[]> array_packedvector3array
     {
         get => GdObject.Get("array_packedvector3array").As<Godot.Collections.Array<Godot.Vector3[]>>();
-        set => GdObject.Set("array_packedvector3array", value);
+        set => GdObject.Set("array_packedvector3array", Godot.Variant.From(value));
     }
 
     public Godot.Collections.Array<Godot.Plane> array_plane
     {
         get => GdObject.Get("array_plane").As<Godot.Collections.Array<Godot.Plane>>();
-        set => GdObject.Set("array_plane", value);
+        set => GdObject.Set("array_plane", Godot.Variant.From(value));
     }
 
     public Godot.Collections.Array<Godot.Projection> array_projection
     {
         get => GdObject.Get("array_projection").As<Godot.Collections.Array<Godot.Projection>>();
-        set => GdObject.Set("array_projection", value);
+        set => GdObject.Set("array_projection", Godot.Variant.From(value));
     }
 
     public Godot.Collections.Array<Godot.Quaternion> array_quaternion
     {
         get => GdObject.Get("array_quaternion").As<Godot.Collections.Array<Godot.Quaternion>>();
-        set => GdObject.Set("array_quaternion", value);
+        set => GdObject.Set("array_quaternion", Godot.Variant.From(value));
     }
 
     public Godot.Collections.Array<Godot.Rect2> array_rect2
     {
         get => GdObject.Get("array_rect2").As<Godot.Collections.Array<Godot.Rect2>>();
-        set => GdObject.Set("array_rect2", value);
+        set => GdObject.Set("array_rect2", Godot.Variant.From(value));
     }
 
     public Godot.Collections.Array<Godot.Rect2I> array_rect2i
     {
         get => GdObject.Get("array_rect2i").As<Godot.Collections.Array<Godot.Rect2I>>();
-        set => GdObject.Set("array_rect2i", value);
+        set => GdObject.Set("array_rect2i", Godot.Variant.From(value));
     }
 
     public Godot.Collections.Array<Godot.Rid> array_rid
     {
         get => GdObject.Get("array_rid").As<Godot.Collections.Array<Godot.Rid>>();
-        set => GdObject.Set("array_rid", value);
+        set => GdObject.Set("array_rid", Godot.Variant.From(value));
     }
 
     public Godot.Collections.Array<Godot.Signal> array_signal
     {
         get => GdObject.Get("array_signal").As<Godot.Collections.Array<Godot.Signal>>();
-        set => GdObject.Set("array_signal", value);
+        set => GdObject.Set("array_signal", Godot.Variant.From(value));
     }
 
     public Godot.Collections.Array<string> array_string
     {
         get => GdObject.Get("array_string").As<Godot.Collections.Array<string>>();
-        set => GdObject.Set("array_string", value);
+        set => GdObject.Set("array_string", Godot.Variant.From(value));
     }
 
     public Godot.Collections.Array<Godot.StringName> array_stringname
     {
         get => GdObject.Get("array_stringname").As<Godot.Collections.Array<Godot.StringName>>();
-        set => GdObject.Set("array_stringname", value);
+        set => GdObject.Set("array_stringname", Godot.Variant.From(value));
     }
 
     public Godot.Collections.Array<Godot.Transform2D> array_transform2d
     {
         get => GdObject.Get("array_transform2d").As<Godot.Collections.Array<Godot.Transform2D>>();
-        set => GdObject.Set("array_transform2d", value);
+        set => GdObject.Set("array_transform2d", Godot.Variant.From(value));
     }
 
     public Godot.Collections.Array<Godot.Transform3D> array_transform3d
     {
         get => GdObject.Get("array_transform3d").As<Godot.Collections.Array<Godot.Transform3D>>();
-        set => GdObject.Set("array_transform3d", value);
+        set => GdObject.Set("array_transform3d", Godot.Variant.From(value));
     }
 
     public Godot.Collections.Array<Godot.Vector2> array_vector2
     {
         get => GdObject.Get("array_vector2").As<Godot.Collections.Array<Godot.Vector2>>();
-        set => GdObject.Set("array_vector2", value);
+        set => GdObject.Set("array_vector2", Godot.Variant.From(value));
     }
 
     public Godot.Collections.Array<Godot.Vector2I> array_vector2i
     {
         get => GdObject.Get("array_vector2i").As<Godot.Collections.Array<Godot.Vector2I>>();
-        set => GdObject.Set("array_vector2i", value);
+        set => GdObject.Set("array_vector2i", Godot.Variant.From(value));
     }
 
     public Godot.Collections.Array<Godot.Vector3> array_vector3
     {
         get => GdObject.Get("array_vector3").As<Godot.Collections.Array<Godot.Vector3>>();
-        set => GdObject.Set("array_vector3", value);
+        set => GdObject.Set("array_vector3", Godot.Variant.From(value));
     }
 
     public Godot.Collections.Array<Godot.Vector3I> array_vector3i
     {
         get => GdObject.Get("array_vector3i").As<Godot.Collections.Array<Godot.Vector3I>>();
-        set => GdObject.Set("array_vector3i", value);
+        set => GdObject.Set("array_vector3i", Godot.Variant.From(value));
     }
 
     public Godot.Collections.Array<Godot.Vector4> array_vector4
     {
         get => GdObject.Get("array_vector4").As<Godot.Collections.Array<Godot.Vector4>>();
-        set => GdObject.Set("array_vector4", value);
+        set => GdObject.Set("array_vector4", Godot.Variant.From(value));
     }
 
     public Godot.Collections.Array<Godot.Vector4I> array_vector4i
     {
         get => GdObject.Get("array_vector4i").As<Godot.Collections.Array<Godot.Vector4I>>();
-        set => GdObject.Set("array_vector4i", value);
+        set => GdObject.Set("array_vector4i", Godot.Variant.From(value));
     }
 
     public TypedArrayBridge(GodotObject gdObject) : base(gdObject) {}

--- a/GDBridge.Generator/GDBridge.Generator.Tests/Verified/DontUsePascalCaseConfig#ConfigTestBridge.verified.cs
+++ b/GDBridge.Generator/GDBridge.Generator.Tests/Verified/DontUsePascalCaseConfig#ConfigTestBridge.verified.cs
@@ -8,13 +8,13 @@ public partial class ConfigTestBridge : GDScriptBridge
     public Variant snake_case_variable
     {
         get => GdObject.Get("snake_case_variable");
-        set => GdObject.Set("snake_case_variable", value);
+        set => GdObject.Set("snake_case_variable", Godot.Variant.From(value));
     }
 
     public Variant property_var
     {
         get => GdObject.Get("property_var");
-        set => GdObject.Set("property_var", value);
+        set => GdObject.Set("property_var", Godot.Variant.From(value));
     }
 
     public ConfigTestBridge(GodotObject gdObject) : base(gdObject) {}

--- a/GDBridge.Generator/GDBridge.Generator.Tests/Verified/UseGenerateOnlyForMatchingBridgeClassConfigWithMatchingClass#ConfigTestBridge.verified.cs
+++ b/GDBridge.Generator/GDBridge.Generator.Tests/Verified/UseGenerateOnlyForMatchingBridgeClassConfigWithMatchingClass#ConfigTestBridge.verified.cs
@@ -1,4 +1,4 @@
-//HintName: ConfigTestBridge.cs
+﻿//HintName: ConfigTestBridge.cs
 using GDBridge;
 using Godot;
 
@@ -8,13 +8,13 @@ public partial class ConfigTestBridge : GDScriptBridge
     public Variant snake_case_variable
     {
         get => GdObject.Get("snake_case_variable");
-        set => GdObject.Set("snake_case_variable", value);
+        set => GdObject.Set("snake_case_variable", Godot.Variant.From(value));
     }
 
     public Variant property_var
     {
         get => GdObject.Get("property_var");
-        set => GdObject.Set("property_var", value);
+        set => GdObject.Set("property_var", Godot.Variant.From(value));
     }
 
     public ConfigTestBridge(GodotObject gdObject) : base(gdObject) {}

--- a/GDBridge.Generator/GDBridge.Generator.Tests/Verified/UsePascalCaseConfig#ConfigTestBridge.verified.cs
+++ b/GDBridge.Generator/GDBridge.Generator.Tests/Verified/UsePascalCaseConfig#ConfigTestBridge.verified.cs
@@ -8,13 +8,13 @@ public partial class ConfigTestBridge : GDScriptBridge
     public Variant SnakeCaseVariable
     {
         get => GdObject.Get("snake_case_variable");
-        set => GdObject.Set("snake_case_variable", value);
+        set => GdObject.Set("snake_case_variable", Godot.Variant.From(value));
     }
 
     public Variant PropertyVar
     {
         get => GdObject.Get("property_var");
-        set => GdObject.Set("property_var", value);
+        set => GdObject.Set("property_var", Godot.Variant.From(value));
     }
 
     public ConfigTestBridge(GodotObject gdObject) : base(gdObject) {}

--- a/GDBridge.Generator/GDBridge.Generator/BridgeWriter.cs
+++ b/GDBridge.Generator/GDBridge.Generator/BridgeWriter.cs
@@ -32,7 +32,7 @@ class BridgeWriter
                 .WriteLine(
                     $"""
                      get => GdObject.Get("{variable.Name}"){GetTypeCast(variable.Type)};
-                     set => GdObject.Set("{variable.Name}", value);
+                     set => GdObject.Set("{variable.Name}", Godot.Variant.From(value));
                      """)
                 .CloseBlock()
                 .WriteEmptyLines(1);


### PR DESCRIPTION
Currently in the generated property setters, value is passed directly into the Set function. This works for anything that can be implicitly cast to variant, but breaks in certain cases (such as enums like Godot.JoyAxis).
I have changed it to instead explicitly cast to Variant with Variant.From, which correctly handles these cases.